### PR TITLE
Parallel to LoopKit PR 42: Add support for Dexcom Japan and APAC

### DIFF
--- a/ShareClientUI/ShareService+UI.swift
+++ b/ShareClientUI/ShareService+UI.swift
@@ -32,8 +32,9 @@ extension ShareService: ServiceAuthenticationUI {
                 options: [
                     (title: LocalizedString("US", comment: "U.S. share server option title"),
                      value: KnownShareServers.US.rawValue),
-                    (title: LocalizedString("Outside US", comment: "Outside US share server option title"),
-                     value: KnownShareServers.NON_US.rawValue)
+                    (title: LocalizedString("APAC", comment: "Japan, Phillipines, Singapore share server option title"), value: KnownShareServers.APAC.rawValue),
+                    (title: LocalizedString("Worldwide", comment: "Outside US and APAC share server option title"),
+                     value: KnownShareServers.Worldwide.rawValue)
 
                 ]
             )


### PR DESCRIPTION
- Add URL for Dexcom APAC Share API server (covers Japan, Phillipines, Singapore, etc...)
- Add Dexcom Application Id for the new URL as it is different from that of the US and Global.
- Update UI to allow the user to select the APAC Share API server.

see https://github.com/LoopKit/dexcom-share-client-swift/pull/42